### PR TITLE
fix: add null checks to prevent searchUnits() breaking from a unit with no element.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -954,11 +954,11 @@ class MapViewer {
             .includes(current_search_string)
         ) {
           elem?.classList.add('hide');
-          const tooltipClass = elem.getAttribute('aria-describedby');
+          const tooltipClass = elem?.getAttribute('aria-describedby');
           document.getElementById(tooltipClass)?.classList.add('hide');
         } else {
           elem?.classList.remove('hide');
-          const tooltipClass = elem.getAttribute('aria-describedby');
+          const tooltipClass = elem?.getAttribute('aria-describedby');
           document.getElementById(tooltipClass)?.classList.remove('hide');
         }
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -268,7 +268,7 @@ class MapViewer {
   };
 
   addFortificationsToggle = () => {
-    const fortificationsToggleButton = mapper.createToogleLayerButton(
+    const fortificationsToggleButton = mapper.createToggleLayerButton(
       () => this.toggleFortificationsLayer(),
       'Toggle Fortifications',
       'fortifications-toggle-button',
@@ -278,7 +278,7 @@ class MapViewer {
   };
 
   addDragonTeethToggle = () => {
-    const dragonTeethToggleButton = mapper.createToogleLayerButton(
+    const dragonTeethToggleButton = mapper.createToggleLayerButton(
       () => this.toggleDragonTeethLayer(),
       'Toggle Dragon Teeth',
       'dragonteeth-toggle-button',
@@ -288,7 +288,7 @@ class MapViewer {
   };
 
   addUnitsToggle = () => {
-    const unitsToggleButton = mapper.createToogleLayerButton(
+    const unitsToggleButton = mapper.createToggleLayerButton(
       () => this.toggleUnitsLayer(),
       'Toggle Units',
       'units-toggle-button',
@@ -298,7 +298,7 @@ class MapViewer {
   };
 
   addGeosToggle = () => {
-    const geosToggleButton = mapper.createToogleLayerButton(
+    const geosToggleButton = mapper.createToggleLayerButton(
       () => this.toggleGeosLayer(),
       'Toggle Geolocations',
       'geolocations-toggle-button',
@@ -308,7 +308,7 @@ class MapViewer {
   };
 
   addUnitLabelToggle = () => {
-    const unitLabelsToggleButton = mapper.createToogleLayerButton(
+    const unitLabelsToggleButton = mapper.createToggleLayerButton(
       () => this.toggleUnitLabels(),
       'Toggle Unit Labels permanently on (at zoomlevel >= 11)',
       'unitlabels-toggle-button',

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,19 +80,57 @@ class MapViewer {
     // set date input to correct date
     this.updateDateInput();
 
-    // add listener
+    // add listeners
     this.addTimelineControlListener();
     this.addMapZoomListener();
     this.addMapMoveListener();
     this.addSearchInputListener();
 
+    // 
     // add toggle buttons
-    this.addTimelineControlToggle();
-    this.addFortificationsToggle();
-    this.addDragonTeethToggle();
-    this.addUnitsToggle();
-    this.addGeosToggle();
-    this.addUnitLabelToggle();
+    // 
+
+    this.addToggleButton(
+      this.toggleTimelineControl,
+      'Toggle Timeline Controls',
+      'timeline-toggle-button',
+      this.layer_status.timeline
+    );
+    
+    this.addToggleButton(
+      this.toggleFortificationsLayer,
+      'Toggle Fortifications',
+      'fortifications-toggle-button',
+      this.layer_status.fortifications
+    );
+    
+    this.addToggleButton(
+      this.toggleDragonTeethLayer,
+      'Toggle Dragon Teeth',
+      'dragonteeth-toggle-button',
+      this.layer_status.dragon_teeth
+    );
+    
+    this.addToggleButton(
+      this.toggleUnitsLayer,
+      'Toggle Units',
+      'units-toggle-button',
+      this.layer_status.units
+    );
+    
+    this.addToggleButton(
+      this.toggleGeosLayer,
+      'Toggle Geolocations',
+      'geolocations-toggle-button',
+      this.layer_status.geos
+    );
+    
+    this.addToggleButton(
+      this.toggleUnitLabels,
+      'Toggle Unit Labels permanently on (at zoomlevel >= 11)',
+      'unitlabels-toggle-button',
+      this.showPermanentUnitLabels
+    );
 
     // fetch latest data
     await this.fetchData();
@@ -259,62 +297,24 @@ class MapViewer {
   // Toggle Buttons Setup
   //=================================================
 
-  addTimelineControlToggle = () => {
-    const timelineToggleButton = mapper.createTimelineToggleButton(
-      () => this.toggleTimelineControl(),
-      this.layer_status.timeline
+  /**
+   * Creates a button for toggling map features.
+   * @param callbackFn The callback function.
+   * @param title The button title.
+   * @param cls The button dom class.
+   * @param initialStatus The initial state of the button.
+   */
+  addToggleButton = (
+    callbackFn: Function,
+    title: string,
+    cls: string,
+    initialStatus: boolean
+  ) => {
+    const toggleButton = mapper.createToggleButton(
+      () => callbackFn(), title, cls, initialStatus
     );
-    timelineToggleButton.addTo(this.map);
-  };
 
-  addFortificationsToggle = () => {
-    const fortificationsToggleButton = mapper.createToggleLayerButton(
-      () => this.toggleFortificationsLayer(),
-      'Toggle Fortifications',
-      'fortifications-toggle-button',
-      this.layer_status.fortifications
-    );
-    fortificationsToggleButton.addTo(this.map);
-  };
-
-  addDragonTeethToggle = () => {
-    const dragonTeethToggleButton = mapper.createToggleLayerButton(
-      () => this.toggleDragonTeethLayer(),
-      'Toggle Dragon Teeth',
-      'dragonteeth-toggle-button',
-      this.layer_status.dragon_teeth
-    );
-    dragonTeethToggleButton.addTo(this.map);
-  };
-
-  addUnitsToggle = () => {
-    const unitsToggleButton = mapper.createToggleLayerButton(
-      () => this.toggleUnitsLayer(),
-      'Toggle Units',
-      'units-toggle-button',
-      this.layer_status.units
-    );
-    unitsToggleButton.addTo(this.map);
-  };
-
-  addGeosToggle = () => {
-    const geosToggleButton = mapper.createToggleLayerButton(
-      () => this.toggleGeosLayer(),
-      'Toggle Geolocations',
-      'geolocations-toggle-button',
-      this.layer_status.geos
-    );
-    geosToggleButton.addTo(this.map);
-  };
-
-  addUnitLabelToggle = () => {
-    const unitLabelsToggleButton = mapper.createToggleLayerButton(
-      () => this.toggleUnitLabels(),
-      'Toggle Unit Labels permanently on (at zoomlevel >= 11)',
-      'unitlabels-toggle-button',
-      this.showPermanentUnitLabels
-    );
-    unitLabelsToggleButton.addTo(this.map);
+    toggleButton.addTo(this.map);
   };
 
   //=================================================
@@ -773,6 +773,7 @@ class MapViewer {
   //---------------------------------------------------------
 
   createUnitLayers = () => {
+    /// BUG: Something might be broken here, related to issue #12.
     if (this.baseData === null) {
       return;
     }

--- a/src/map.ts
+++ b/src/map.ts
@@ -15,16 +15,13 @@ declare module 'leaflet' {
   }
 }
 
+/**
+ * Initializes the leaflet base map.
+ * @returns The leaflet map.
+ */
 export const initBaseMap = () => {
-  const lat = 47.5;
-  const lng = 36.0;
-  // const lat = 45.94153243267059; // dev
-  // const lng = 36.56250000000001; // dev
-  const zoom = 7; // initial zoom level
-  // const zoom = 10; // dev
-
-  // map center
-  const mapcenter: any = [lat, lng];
+  const initialZoom = 7;
+  const mapCenter: any = [47.5, 36.0];
 
   // OSM tile layer
   const cyclosmUrl =
@@ -107,8 +104,8 @@ export const initBaseMap = () => {
   // create base map with OSM layer as default
   const map = L.map('map', {
     layers: [cyclosm],
-    center: mapcenter,
-    zoom: zoom,
+    center: mapCenter,
+    zoom: initialZoom,
     minZoom: 4,
     maxZoom: 18,
     maxBounds: [
@@ -151,52 +148,32 @@ export const initBaseMap = () => {
   return map;
 };
 
-export const createTimelineToggleButton = (
-  cb: Function,
-  initialStatus: boolean
-) => {
-  // toggle button
-  const toggleButtonControl = L.Control.extend({
-    onAdd: function () {
-      const statusCls = initialStatus ? 'active' : 'inactive';
-      const button = L.DomUtil.create(
-        'button',
-        `toggle-button timeline-toggle-button ${statusCls}`
-      );
-      button.title = 'Toggle Timeline Controls';
-      L.DomEvent.disableClickPropagation(button);
-      L.DomEvent.on(button, 'click', function () {
-        cb();
-      });
-      return button;
-    },
-  });
-  const toggleButton = new toggleButtonControl({ position: 'topright' });
-  return toggleButton;
-};
-
-export const createToggleLayerButton = (
+export const createToggleButton = (
   callback: Function,
   title: string,
   cls: string,
   initialStatus: boolean
 ) => {
-  // toggle button
-  const toggleLayerButton = L.Control.extend({
-    onAdd: function () {
+  const toggleButtonControl = L.Control.extend({
+    onAdd: () => {
       const statusCls = initialStatus ? 'active' : 'inactive';
+      
       const button = L.DomUtil.create(
         'button',
         `toggle-button ${cls} ${statusCls}`
       );
+
       button.title = title;
       L.DomEvent.disableClickPropagation(button);
-      L.DomEvent.on(button, 'click', function () {
+      
+      L.DomEvent.on(button, 'click', () => {
         callback();
       });
+      
       return button;
-    },
+    }
   });
-  const toggleButton = new toggleLayerButton({ position: 'topright' });
+
+  const toggleButton = new toggleButtonControl({ position: 'topright' });
   return toggleButton;
 };

--- a/src/map.ts
+++ b/src/map.ts
@@ -175,7 +175,7 @@ export const createTimelineToggleButton = (
   return toggleButton;
 };
 
-export const createToogleLayerButton = (
+export const createToggleLayerButton = (
   callback: Function,
   title: string,
   cls: string,


### PR DESCRIPTION
This is a quick and simple fix for the bug mentioned in issue #12.  

I'm certain this fix will only solve this one edge case, as this doesn't solve the problem of invalid units being kept in `layer_units`.